### PR TITLE
Create indexed tokens page and enhance navigation

### DIFF
--- a/backend/app/web/api/__init__.py
+++ b/backend/app/web/api/__init__.py
@@ -5,6 +5,7 @@ from .auth import router as auth_router
 from .deck import router as deck_router
 from .card_stats import router as card_stats_router
 from .extension import router as extension_router
+from .tokens import router as tokens_router
 
 
 __all__ = ["card_router", "auth_router", "deck_router", "card_stats_router", "extension_router"]
@@ -17,3 +18,4 @@ router.include_router(auth_router)
 router.include_router(deck_router)
 router.include_router(card_stats_router)
 router.include_router(extension_router)
+router.include_router(tokens_router)

--- a/backend/app/web/api/tokens.py
+++ b/backend/app/web/api/tokens.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+from datetime import datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query
+
+from ..auth.deps import ProtectedDep
+from ...database.types.pagination import Pagination, PaginationQuery
+from pydantic import BaseModel, Field
+
+router = APIRouter(prefix="/tokens", tags=["tokens"])  # /api/tokens via parent include
+
+
+class IndexedToken(BaseModel):
+    symbol: str
+    name: str | None = None
+    mentions_24h: int = 0
+    last_seen_at: datetime | None = None
+
+
+class IndexedTokensResponse(Pagination[IndexedToken]):
+    pass
+
+
+class ParsedContentItem(BaseModel):
+    id: str
+    source: str  # e.g., telegram:@channel, fourchan:/b/
+    source_url: str | None = None
+    content: str
+    created_at: datetime
+    tokens: list[str] = Field(default_factory=list)
+
+
+class ParsedContentResponse(Pagination[ParsedContentItem]):
+    pass
+
+
+@router.post("/list", response_model=IndexedTokensResponse)
+async def list_indexed_tokens(
+    _: ProtectedDep,
+    query: PaginationQuery,
+):
+    # Mocked data until real repo exists
+    items: list[IndexedToken] = [
+        IndexedToken(symbol="BTC", name="Bitcoin", mentions_24h=120, last_seen_at=datetime.utcnow()),
+        IndexedToken(symbol="ETH", name="Ethereum", mentions_24h=95, last_seen_at=datetime.utcnow()),
+    ]
+
+    page = query.page or 1
+    per_page = query.per_page or 10
+    start = (page - 1) * per_page
+    end = start + per_page
+    paged = items[start:end]
+    return IndexedTokensResponse(total=len(items), page=page, per_page=per_page, items=paged)
+
+
+@router.post("/parsed-content", response_model=ParsedContentResponse)
+async def list_parsed_content(
+    _: ProtectedDep,
+    query: PaginationQuery,
+    start_date: Annotated[datetime | None, Query(None)] = None,
+    end_date: Annotated[datetime | None, Query(None)] = None,
+):
+    # Mocked data; filter by optional dates
+    data: list[ParsedContentItem] = [
+        ParsedContentItem(
+            id="1",
+            source="telegram:@crypto_news",
+            source_url="https://t.me/crypto_news/123",
+            content="BTC pumping hard. ETH looking strong.",
+            created_at=datetime.utcnow(),
+            tokens=["BTC", "ETH"],
+        ),
+        ParsedContentItem(
+            id="2",
+            source="4chan:/biz/",
+            source_url="https://boards.4channel.org/biz/thread/456",
+            content="Is SOL the next big thing?",
+            created_at=datetime.utcnow(),
+            tokens=["SOL"],
+        ),
+    ]
+
+    def within_range(item: ParsedContentItem) -> bool:
+        if start_date and item.created_at < start_date:
+            return False
+        if end_date and item.created_at > end_date:
+            return False
+        return True
+
+    filtered = [d for d in data if within_range(d)]
+    page = query.page or 1
+    per_page = query.per_page or 10
+    start = (page - 1) * per_page
+    end = start + per_page
+    paged = filtered[start:end]
+    return ParsedContentResponse(total=len(filtered), page=page, per_page=per_page, items=paged)
+

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,10 @@ import {
   CardDetailPage,
   RandomAnimeGifPage, 
   SettingsPage,
-  FQAPage
+  FQAPage,
+  IndexedTokensPage,
+  TokenSentimentPage,
+  ParsedContentPage
 } from './pages';
 import { DecksListPage, DeckDetailPage } from './pages/decks';
 import Header from './components/Header';
@@ -59,6 +62,21 @@ function App() {
                     </ProtectedRoute>
                   } />
                   <Route path="/fqa" element={<FQAPage />} />
+                  <Route path="/tokens" element={
+                    <ProtectedRoute>
+                      <IndexedTokensPage />
+                    </ProtectedRoute>
+                  } />
+                  <Route path="/token/:symbol" element={
+                    <ProtectedRoute>
+                      <TokenSentimentPage />
+                    </ProtectedRoute>
+                  } />
+                  <Route path="/parsed-content" element={
+                    <ProtectedRoute>
+                      <ParsedContentPage />
+                    </ProtectedRoute>
+                  } />
                   <Route path="/" element=
                     {
                     <ProtectedRoute>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -25,6 +25,12 @@ const Header = () => {
           <NavLink to="/random-gif" className={({ isActive }) => isActive ? "nav-link active" : "nav-link"}>
             {t('navigation.randomGif')}
           </NavLink>
+          <NavLink to="/tokens" className={({ isActive }) => isActive ? "nav-link active" : "nav-link"}>
+            {t('navigation.tokens')}
+          </NavLink>
+          <NavLink to="/parsed-content" className={({ isActive }) => isActive ? "nav-link active" : "nav-link"}>
+            {t('navigation.parsedContent')}
+          </NavLink>
           <NavLink to="/fqa" className={({ isActive }) => isActive ? "nav-link active" : "nav-link"}>
             {t('navigation.fqa')}
           </NavLink>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -57,10 +57,27 @@
     "cards": "Cards",
     "decks": "Decks",
     "randomGif": "Random GIF",
+    "tokens": "Tokens",
+    "parsedContent": "Parsed Content",
     "account": "Account",
     "extension": "Browser Extension",
     "sessions": "Sessions",
     "fqa": "FAQ"
+  },
+  "tokensPage": {
+    "title": "Indexed Tokens",
+    "viewParsedContent": "View Parsed Content"
+  },
+  "tokenSentiment": {
+    "title": "Token Sentiment: {{symbol}}",
+    "viewAllTokens": "View All Tokens"
+  },
+  "parsedContent": {
+    "title": "Parsed Content",
+    "from": "From",
+    "to": "To",
+    "source": "Source",
+    "createdAt": "Created At"
   },
   "auth": {
     "login": "Login",

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -9,3 +9,8 @@ export * from './settings';
 
 // FQA page
 export { default as FQAPage } from './FQAPage'; 
+
+// Tokens and content pages
+export { default as IndexedTokensPage } from './tokens/IndexedTokensPage';
+export { default as TokenSentimentPage } from './tokens/TokenSentimentPage';
+export { default as ParsedContentPage } from './tokens/ParsedContentPage';

--- a/frontend/src/pages/tokens/IndexedTokensPage.tsx
+++ b/frontend/src/pages/tokens/IndexedTokensPage.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import PaginationPage, { PaginationQuery, PaginationResponse } from '../../components/PaginationPage';
+import { EntityFilterConfig, GenericFilter } from '../../types/filter';
+import authAxios from '../../utils/authAxios';
+import { Link, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+interface IndexedToken {
+  symbol: string;
+  name?: string | null;
+  mentions_24h: number;
+  last_seen_at?: string | null;
+}
+
+const filterConfig: EntityFilterConfig = {
+  entityName: 'Tokens',
+  fieldOptions: [
+    { value: 'symbol', label: 'Symbol', type: 'string' },
+    { value: 'name', label: 'Name', type: 'string' },
+  ],
+  shortFilterFields: [
+    { key: 'symbol', type: 'text', placeholder: 'Symbol' },
+    { key: 'name', type: 'text', placeholder: 'Name' },
+  ],
+  buildShortFilter: (values: Record<string, string>): GenericFilter | null => {
+    const filters: GenericFilter[] = [];
+    if (values.symbol) filters.push({ symbol: { icontains: values.symbol } });
+    if (values.name) filters.push({ name: { icontains: values.name } });
+    if (filters.length === 0) return null;
+    if (filters.length === 1) return filters[0];
+    return { and: filters };
+  },
+  sortOptions: [
+    { value: 'mentions_24h:desc', label: 'Mentions 24h (desc)' },
+    { value: 'mentions_24h:asc', label: 'Mentions 24h (asc)' },
+    { value: 'symbol:asc', label: 'Symbol (A-Z)' },
+  ],
+  defaults: {
+    sort: 'mentions_24h:desc',
+    filterMode: 'short',
+  },
+  ui: {
+    title: 'Indexed Tokens'
+  }
+};
+
+const fetchTokens = async (query: PaginationQuery): Promise<PaginationResponse<IndexedToken>> => {
+  const resp = await authAxios.post('/api/tokens/list', {
+    page: query.page || 1,
+    per_page: query.per_page || 20,
+    filter: query.filter || undefined,
+    order_by: query.order_by || undefined,
+  });
+  return resp.data as PaginationResponse<IndexedToken>;
+};
+
+const IndexedTokensPage: React.FC = () => {
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+  return (
+    <PaginationPage<IndexedToken>
+      title={t('tokensPage.title')}
+      fetchData={fetchTokens}
+      filterConfig={filterConfig}
+      renderItems={(items) => (
+        <div className="list">
+          {items.map(item => (
+            <div key={item.symbol} className="list-row clickable" onClick={() => navigate(`/token/${encodeURIComponent(item.symbol)}`)}>
+              <div className="cell strong">{item.symbol}</div>
+              <div className="cell">{item.name || '-'}</div>
+              <div className="cell">{item.mentions_24h}</div>
+              <div className="cell">{item.last_seen_at ? new Date(item.last_seen_at).toLocaleString() : '-'}</div>
+            </div>
+          ))}
+        </div>
+      )}
+      headerActions={<Link to="/parsed-content">{t('tokensPage.viewParsedContent')}</Link>}
+    />
+  );
+};
+
+export default IndexedTokensPage;
+

--- a/frontend/src/pages/tokens/ParsedContentPage.tsx
+++ b/frontend/src/pages/tokens/ParsedContentPage.tsx
@@ -1,0 +1,139 @@
+import React, { useMemo } from 'react';
+import PaginationPage, { PaginationQuery, PaginationResponse } from '../../components/PaginationPage';
+import { EntityFilterConfig, GenericFilter } from '../../types/filter';
+import authAxios from '../../utils/authAxios';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+interface ParsedContentItem {
+  id: string;
+  source: string;
+  source_url?: string | null;
+  content: string;
+  created_at: string;
+  tokens: string[];
+}
+
+const filterConfig: EntityFilterConfig = {
+  entityName: 'Parsed Content',
+  fieldOptions: [
+    { value: 'source', label: 'Source', type: 'string' },
+    { value: 'content', label: 'Content', type: 'string' },
+    { value: 'created_at', label: 'Created At', type: 'datetime' },
+  ],
+  shortFilterFields: [
+    { key: 'source', type: 'text', placeholder: 'Source' },
+    { key: 'content', type: 'text', placeholder: 'Search content' },
+  ],
+  buildShortFilter: (values: Record<string, string>): GenericFilter | null => {
+    const filters: GenericFilter[] = [];
+    if (values.source) filters.push({ source: { icontains: values.source } });
+    if (values.content) filters.push({ content: { icontains: values.content } });
+    if (filters.length === 0) return null;
+    if (filters.length === 1) return filters[0];
+    return { and: filters };
+  },
+  sortOptions: [
+    { value: 'created_at:desc', label: 'Newest' },
+    { value: 'created_at:asc', label: 'Oldest' },
+  ],
+  defaults: {
+    sort: 'created_at:desc',
+    filterMode: 'short',
+  },
+  ui: {
+    title: 'Parsed Content'
+  }
+};
+
+const fetchParsedContent = async (query: PaginationQuery & { start_date?: string; end_date?: string }): Promise<PaginationResponse<ParsedContentItem>> => {
+  const resp = await authAxios.post('/api/tokens/parsed-content', {
+    page: query.page || 1,
+    per_page: query.per_page || 20,
+    filter: query.filter || undefined,
+    order_by: query.order_by || undefined,
+  }, {
+    params: {
+      start_date: query.start_date,
+      end_date: query.end_date,
+    }
+  });
+  return resp.data as PaginationResponse<ParsedContentItem>;
+};
+
+const ParsedContentPage: React.FC = () => {
+  const { t } = useTranslation();
+  const buildQuery = useMemo(() => {
+    return (page: number, perPage: number, filter: GenericFilter | null, sortBy: string) => {
+      const url = new URL(window.location.href);
+      const start_date = url.searchParams.get('start_date') || undefined;
+      const end_date = url.searchParams.get('end_date') || undefined;
+      return {
+        page,
+        per_page: perPage,
+        filter,
+        order_by: sortBy,
+        start_date,
+        end_date,
+      } as any;
+    };
+  }, []);
+
+  return (
+    <PaginationPage<ParsedContentItem, GenericFilter, any>
+      title={t('parsedContent.title')}
+      fetchData={fetchParsedContent as any}
+      buildQuery={buildQuery}
+      filterConfig={filterConfig}
+      headerActions={(
+        <div className="date-range-controls">
+          <label>
+            {t('parsedContent.from')}:
+            <input type="datetime-local" defaultValue="" onChange={(e) => {
+              const params = new URLSearchParams(window.location.search);
+              if (e.target.value) params.set('start_date', new Date(e.target.value).toISOString()); else params.delete('start_date');
+              window.history.replaceState({}, '', `${window.location.pathname}?${params.toString()}`);
+            }} />
+          </label>
+          <label>
+            {t('parsedContent.to')}:
+            <input type="datetime-local" defaultValue="" onChange={(e) => {
+              const params = new URLSearchParams(window.location.search);
+              if (e.target.value) params.set('end_date', new Date(e.target.value).toISOString()); else params.delete('end_date');
+              window.history.replaceState({}, '', `${window.location.pathname}?${params.toString()}`);
+            }} />
+          </label>
+        </div>
+      )}
+      renderItems={(items) => (
+        <div className="list">
+          {items.map(item => (
+            <div key={item.id} className="list-row">
+              <div className="cell small">
+                {item.source_url ? (
+                  <a href={item.source_url} target="_blank" rel="noopener noreferrer">{item.source}</a>
+                ) : (
+                  item.source
+                )}
+              </div>
+              <div className="cell grow">
+                {item.content}
+                {!!item.tokens?.length && (
+                  <div className="tokens">
+                    {item.tokens.map(tok => (
+                      <Link key={tok} to={`/token/${encodeURIComponent(tok)}`} className="token-link">{tok}</Link>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <div className="cell small">{new Date(item.created_at).toLocaleString()}</div>
+            </div>
+          ))}
+        </div>
+      )}
+    />
+  );
+};
+
+export default ParsedContentPage;
+

--- a/frontend/src/pages/tokens/TokenSentimentPage.tsx
+++ b/frontend/src/pages/tokens/TokenSentimentPage.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+const TokenSentimentPage: React.FC = () => {
+  const { symbol } = useParams();
+  const { t } = useTranslation();
+  return (
+    <div className="token-sentiment-page">
+      <div className="page-header">
+        <h1>{t('tokenSentiment.title', { symbol })}</h1>
+        <div className="actions">
+          <Link to="/tokens" className="button">{t('tokenSentiment.viewAllTokens')}</Link>
+        </div>
+      </div>
+      <div className="content">
+        <p>Sentiment analysis coming soon.</p>
+      </div>
+    </div>
+  );
+};
+
+export default TokenSentimentPage;
+

--- a/frontend/src/utils/authAxios.ts
+++ b/frontend/src/utils/authAxios.ts
@@ -1,0 +1,29 @@
+import axios from 'axios';
+
+const authAxios = axios.create({
+  baseURL: import.meta.env.VITE_API_URL,
+});
+
+authAxios.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    config.headers = config.headers || {};
+    (config.headers as any)['Authorization'] = `Bearer ${token}`;
+  }
+  return config;
+});
+
+authAxios.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401) {
+      localStorage.removeItem('token');
+      localStorage.removeItem('username');
+      window.location.href = '/login';
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default authAxios;
+


### PR DESCRIPTION
New backend endpoints were added in app/web/api/tokens.py for listing indexed tokens and parsed content, including date filtering. Frontend routes were established in src/App.tsx for /tokens, /token/:symbol, and /parsed-content. New pages (IndexedTokensPage, TokenSentimentPage, ParsedContentPage) were created, featuring clickable tokens to sentiment analysis, source links, and date range filtering. Navigation in src/components/Header.tsx and i18n strings in src/locales/en.json were updated. An authAxios utility was introduced for authenticated API calls.